### PR TITLE
ENH: add 'pretrained' and 'weigths_path', fix #87

### DIFF
--- a/src/searchnets/__main__.py
+++ b/src/searchnets/__main__.py
@@ -42,6 +42,8 @@ def _call_train(config):
           pad_size=config.data.pad_size,
           save_path=config.train.save_path,
           method=config.train.method,
+          pretrained=config.train.pretrained,
+          weights_path=config.train.weights_path,
           mode=config.train.mode,
           num_classes=config.data.num_classes,
           learning_rate=config.train.learning_rate,

--- a/src/searchnets/config/parse.py
+++ b/src/searchnets/config/parse.py
@@ -165,6 +165,16 @@ def parse_config(config_fname):
     else:
         method = 'transfer'
 
+    if config.has_option('TRAIN', 'PRETRAINED'):
+        pretrained = bool(strtobool(config['TRAIN']['PRETRAINED']))
+    else:
+        pretrained = True
+
+    if config.has_option('TRAIN', 'WEIGHTS_PATH'):
+        weights_path = config['TRAIN']['WEIGHTS_PATH']
+    else:
+        weights_path = None
+
     if config.has_option('TRAIN', 'MODE'):
         mode = config['TRAIN']['MODE']
     else:
@@ -258,6 +268,8 @@ def parse_config(config_fname):
                                random_seed=random_seed,
                                save_path=save_path,
                                method=method,
+                               pretrained=pretrained,
+                               weights_path=weights_path,
                                mode=mode,
                                learning_rate=learning_rate,
                                new_learn_rate_layers=new_learn_rate_layers,

--- a/src/searchnets/config/train.py
+++ b/src/searchnets/config/train.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import attr
-from attr import validators
+from attr import converters, validators
 from attr.validators import instance_of
 
 from ..utils.general import projroot_path
@@ -75,6 +75,13 @@ class TrainConfig:
         'transfer' means perform transfer learning, using weights pre-trained
         on imagenet.
         Default is 'transfer'.
+    pretrained : bool
+        whether to load pre-trained model weights. Default is True.
+    weights_path : str
+        path to pre-trained model weights. Default is ``None``.
+        If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
+        then the pre-trained weights will be loaded from the urls
+        associated with the models.
     mode : str
         training mode. One of {'classify', 'detect'}.
         'classify' is standard image classification.
@@ -158,6 +165,12 @@ class TrainConfig:
             raise ValueError(
                 f"method must be one of {{'initialize', 'transfer'}}, but was {value}."
             )
+
+    pretrained = attr.ib(validator=instance_of(bool), default=True)
+    weights_path = attr.ib(converter=converters.optional(projroot_path),
+                           validator=validators.optional(instance_of(Path)),
+                           default=None)
+
     mode = attr.ib(validator=instance_of(str), default='classify')
     @mode.validator
     def check_method(self, attribute, value):

--- a/src/searchnets/engine/trainer.py
+++ b/src/searchnets/engine/trainer.py
@@ -21,6 +21,8 @@ class Trainer(AbstractTrainer):
                     num_classes,
                     trainset,
                     mode='classify',
+                    pretrained=False,
+                    weights_path=None,
                     optimizer='SGD',
                     embedding_n_out=512,
                     learning_rate=0.001,
@@ -36,6 +38,20 @@ class Trainer(AbstractTrainer):
             One of {'alexnet', 'VGG16'}
         num_classes : int
             number of classes. Default is 2 (target present, target absent).
+        trainset : torch.utils.data.Dataset
+            instance of one of the sub-classes in ``searchnets.datasets``
+        mode : str
+            training mode. One of {'classify', 'detect'}.
+            'classify' is standard image classification.
+            'detect' trains to detect whether specified target is present or absent.
+            Default is 'classify'.
+        pretrained : bool
+            whether to load pre-trained model weights. Default is False.
+        weights_path : str
+            path to pre-trained model weights. Default is ``None``.
+            If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
+            then the pre-trained weights will be loaded from the urls
+            associated with the models.
         optimizer : str
             optimizer to use. One of {'SGD', 'Adam', 'AdamW'}.
         embedding_n_out : int
@@ -56,11 +72,11 @@ class Trainer(AbstractTrainer):
         trainer : Trainer
         """
         if net_name == 'alexnet':
-            model = nets.alexnet.build(pretrained=False, num_classes=num_classes)
+            model = nets.alexnet.build(pretrained=pretrained, weights_path=weights_path, num_classes=num_classes)
         elif net_name == 'VGG16':
-            model = nets.vgg16.build(pretrained=False, num_classes=num_classes)
+            model = nets.vgg16.build(pretrained=pretrained, weights_path=weights_path, num_classes=num_classes)
         elif 'cornet' in net_name.lower():
-            model = nets.cornet.build(model_name=net_name, pretrained=False,
+            model = nets.cornet.build(model_name=net_name, pretrained=False,  weights_path=weights_path,
                                       num_classes=num_classes)
         else:
             raise ValueError(

--- a/src/searchnets/engine/transfer_trainer.py
+++ b/src/searchnets/engine/transfer_trainer.py
@@ -19,6 +19,8 @@ class TransferTrainer(AbstractTrainer):
                     net_name,
                     new_learn_rate_layers,
                     trainset,
+                    pretrained=True,
+                    weights_path=None,
                     mode='classify',
                     num_classes=2,
                     embedding_n_out=512,
@@ -41,6 +43,13 @@ class TransferTrainer(AbstractTrainer):
             and then trained with the 'new_layer_learning_rate'.
         trainset : torch.Dataset or torchvision.Visiondataset
             training data, represented as a class.
+        pretrained : bool
+            whether to load pre-trained model weights. Default is True.
+        weights_path : str
+            path to pre-trained model weights. Default is ``None``.
+            If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
+            then the pre-trained weights will be loaded from the urls
+            associated with the models.
         mode : str
             training mode. One of {'classify', 'detect'}.
             'classify' is standard image classification.
@@ -78,13 +87,13 @@ class TransferTrainer(AbstractTrainer):
         trainer : TransferTrainer
         """
         if net_name == 'alexnet':
-            model = nets.alexnet.build(pretrained=True, progress=True)
+            model = nets.alexnet.build(pretrained=pretrained, weights_path=weights_path, progress=True)
             model = nets.alexnet.reinit(model, new_learn_rate_layers, num_classes=num_classes)
         elif net_name == 'VGG16':
-            model = nets.vgg16.build(pretrained=True, progress=True)
+            model = nets.vgg16.build(pretrained=pretrained, weights_path=weights_path, progress=True)
             model = nets.vgg16.reinit(model, new_learn_rate_layers, num_classes=num_classes)
         elif 'cornet' in net_name.lower():
-            model = nets.cornet.build(model_name=net_name, pretrained=True)
+            model = nets.cornet.build(model_name=net_name, pretrained=pretrained, weights_path=weights_path)
             model = nets.cornet.reinit(model, model_name=net_name, num_classes=num_classes)
         else:
             raise ValueError(

--- a/src/searchnets/nets/alexnet.py
+++ b/src/searchnets/nets/alexnet.py
@@ -49,7 +49,7 @@ class AlexNet(nn.Module):
         return x
 
 
-def build(pretrained=False, progress=True, **kwargs):
+def build(pretrained=False, progress=True, weights_path=None, **kwargs):
     r"""AlexNet model architecture from the
     `"One weird trick..." <https://arxiv.org/abs/1404.5997>`_ paper.
 
@@ -59,8 +59,20 @@ def build(pretrained=False, progress=True, **kwargs):
     """
     model = AlexNet(**kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['alexnet'],
-                                              progress=progress)
+        if weights_path:
+            ckpt = torch.load(weights_path)
+            if 'state_dict' in ckpt:
+                state_dict = ckpt['state_dict']
+            else:
+                state_dict = ckpt  # assume checkpoint is just state dict
+        else:
+            state_dict = load_state_dict_from_url(model_urls['alexnet'],
+                                                  progress=progress)
+        if any(['module.' in k for k in state_dict.keys()]):
+            state_dict = {
+                k.replace('module.', ''): v
+                for k, v in state_dict.items()
+            }
         model.load_state_dict(state_dict)
     return model
 

--- a/src/searchnets/train.py
+++ b/src/searchnets/train.py
@@ -21,6 +21,8 @@ def train(csv_file,
           root=None,
           pad_size=VSD_PAD_SIZE,
           method='transfer',
+          pretrained=True,
+          weights_path=None,
           mode='classify',
           num_classes=2,
           learning_rate=None,
@@ -75,6 +77,13 @@ def train(csv_file,
         'transfer' means perform transfer learning, using weights pre-trained
         on imagenet.
         Default is 'transfer'.
+    pretrained : bool
+        whether to load pre-trained model weights. Default is True.
+    weights_path : str
+        path to pre-trained model weights. Default is ``None``.
+        If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
+        then the pre-trained weights will be loaded from the urls
+        associated with the models.
     mode : str
         training mode. One of {'classify', 'detect'}.
         'classify' is standard image classification.
@@ -239,6 +248,8 @@ def train(csv_file,
             if method == 'transfer':
                 trainer = TransferTrainer.from_config(net_name=net_name,
                                                       trainset=trainset,
+                                                      pretrained=pretrained,
+                                                      weights_path=weights_path,
                                                       new_learn_rate_layers=new_learn_rate_layers,
                                                       freeze_trained_weights=freeze_trained_weights,
                                                       base_learning_rate=base_learning_rate,
@@ -265,6 +276,8 @@ def train(csv_file,
             elif method == 'initialize':
                 trainer = Trainer.from_config(net_name=net_name,
                                               trainset=trainset,
+                                              pretrained=pretrained,
+                                              weights_path=weights_path,
                                               save_path=save_path_this_net,
                                               num_classes=num_classes,
                                               criterion=criterion,


### PR DESCRIPTION
adds ability to specify whether model should be pretrained,
and to specify a path to pre-trained weights that should be loaded

- add 'pretrained' parameter to `TransferTrainer.from_config`
  and `Trainer.from_config` classmethods
- add 'pretrained' attribute to config.TrainConfig
- add 'pretrained' parameter to searchnets.train.train
- have main call train with parameter 'pretrained'
- fix parse so it passes 'pretrained' to `TrainConfig`
- add 'weights_path' parameter to all model `build` functions
- add 'weights_path' parameter to 'from_config' methods
  for Trainer and TransferTrainer
- add 'weights_path' attribute to config.TrainConfig'
- fix 'config.parse' to unpack WEIGHTS_PATH option
  and pass to TrainConfig
- add 'weights_path' parameter to searchnets.train
- have main pass 'config.train.weights_path' to train
- fix how model `build` functions unpack state dict from checkpoint
  + check whether checkpoint contains a `state_dict` key,
    if not, assume checkpoint itself is just state dict
  + remove 'module.' from state_dict keys to avoid crash -- occurs when
    checkpoint was saved during training with `nn.DataParallel`