### PR TITLE
ENH: add 'num_source_classes' to transfer training

### DIFF
--- a/src/searchnets/__main__.py
+++ b/src/searchnets/__main__.py
@@ -44,6 +44,7 @@ def _call_train(config):
           method=config.train.method,
           pretrained=config.train.pretrained,
           weights_path=config.train.weights_path,
+          num_source_classes=config.train.num_source_classes,
           mode=config.train.mode,
           num_classes=config.data.num_classes,
           learning_rate=config.train.learning_rate,

--- a/src/searchnets/config/parse.py
+++ b/src/searchnets/config/parse.py
@@ -175,6 +175,11 @@ def parse_config(config_fname):
     else:
         weights_path = None
 
+    if config.has_option('TRAIN', 'NUM_SOURCE_CLASSES'):
+        num_source_classes = config['TRAIN']['NUM_SOURCE_CLASSES']
+    else:
+        num_source_classes = 1000
+
     if config.has_option('TRAIN', 'MODE'):
         mode = config['TRAIN']['MODE']
     else:
@@ -270,6 +275,7 @@ def parse_config(config_fname):
                                method=method,
                                pretrained=pretrained,
                                weights_path=weights_path,
+                               num_source_classes=num_source_classes,
                                mode=mode,
                                learning_rate=learning_rate,
                                new_learn_rate_layers=new_learn_rate_layers,

--- a/src/searchnets/config/train.py
+++ b/src/searchnets/config/train.py
@@ -82,6 +82,10 @@ class TrainConfig:
         If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
         then the pre-trained weights will be loaded from the urls
         associated with the models.
+    num_source_classes : int
+        number of classes in source dataset that model was trained on.
+        Used when loading weights from ``weights_path``.
+        Default is 1000 (number of classes in ImageNet).
     mode : str
         training mode. One of {'classify', 'detect'}.
         'classify' is standard image classification.
@@ -170,6 +174,7 @@ class TrainConfig:
     weights_path = attr.ib(converter=converters.optional(projroot_path),
                            validator=validators.optional(instance_of(Path)),
                            default=None)
+    num_source_classes = attr.ib(converter=int, default=1000)
 
     mode = attr.ib(validator=instance_of(str), default='classify')
     @mode.validator

--- a/src/searchnets/engine/transfer_trainer.py
+++ b/src/searchnets/engine/transfer_trainer.py
@@ -21,6 +21,7 @@ class TransferTrainer(AbstractTrainer):
                     trainset,
                     pretrained=True,
                     weights_path=None,
+                    num_source_classes=1000,
                     mode='classify',
                     num_classes=2,
                     embedding_n_out=512,
@@ -50,6 +51,10 @@ class TransferTrainer(AbstractTrainer):
             If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
             then the pre-trained weights will be loaded from the urls
             associated with the models.
+        num_source_classes : int
+            number of classes in source dataset that model was trained on.
+            Used when loading weights from ``weights_path``.
+            Default is 1000 (number of classes in ImageNet).
         mode : str
             training mode. One of {'classify', 'detect'}.
             'classify' is standard image classification.
@@ -87,13 +92,16 @@ class TransferTrainer(AbstractTrainer):
         trainer : TransferTrainer
         """
         if net_name == 'alexnet':
-            model = nets.alexnet.build(pretrained=pretrained, weights_path=weights_path, progress=True)
+            model = nets.alexnet.build(pretrained=pretrained, num_classes=num_source_classes,
+                                       weights_path=weights_path, progress=True)
             model = nets.alexnet.reinit(model, new_learn_rate_layers, num_classes=num_classes)
         elif net_name == 'VGG16':
-            model = nets.vgg16.build(pretrained=pretrained, weights_path=weights_path, progress=True)
+            model = nets.vgg16.build(pretrained=pretrained, num_classes=num_source_classes,
+                                     weights_path=weights_path, progress=True)
             model = nets.vgg16.reinit(model, new_learn_rate_layers, num_classes=num_classes)
         elif 'cornet' in net_name.lower():
-            model = nets.cornet.build(model_name=net_name, pretrained=pretrained, weights_path=weights_path)
+            model = nets.cornet.build(model_name=net_name, pretrained=pretrained,
+                                      num_classes=num_source_classes, weights_path=weights_path)
             model = nets.cornet.reinit(model, model_name=net_name, num_classes=num_classes)
         else:
             raise ValueError(

--- a/src/searchnets/nets/alexnet.py
+++ b/src/searchnets/nets/alexnet.py
@@ -49,7 +49,7 @@ class AlexNet(nn.Module):
         return x
 
 
-def build(pretrained=False, progress=True, weights_path=None, **kwargs):
+def build(pretrained=False, progress=True, weights_path=None, num_classes=1000, **kwargs):
     r"""AlexNet model architecture from the
     `"One weird trick..." <https://arxiv.org/abs/1404.5997>`_ paper.
 
@@ -57,7 +57,7 @@ def build(pretrained=False, progress=True, weights_path=None, **kwargs):
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
     """
-    model = AlexNet(**kwargs)
+    model = AlexNet(num_classes=num_classes, **kwargs)
     if pretrained:
         if weights_path:
             ckpt = torch.load(weights_path)

--- a/src/searchnets/nets/cornet.py
+++ b/src/searchnets/nets/cornet.py
@@ -20,7 +20,7 @@ VALID_MODEL_NAMES = frozenset(
 )
 
 
-def build(model_name, pretrained=False, map_location=None, weights_path=None, **kwargs):
+def build(model_name, pretrained=False, map_location=None, weights_path=None, num_classes=1000, **kwargs):
     model_name = model_name.lower()
     if model_name not in VALID_MODEL_NAMES:
         raise ValueError(
@@ -29,7 +29,7 @@ def build(model_name, pretrained=False, map_location=None, weights_path=None, **
         )
     module_name = model_module_map[model_name]
     model_module = sys.modules[module_name]
-    model = model_module.MODEL(**kwargs)
+    model = model_module.MODEL(num_classes=num_classes, **kwargs)
     if pretrained:
         if weights_path:
             ckpt = torch.load(weights_path)

--- a/src/searchnets/nets/vgg16.py
+++ b/src/searchnets/nets/vgg16.py
@@ -75,10 +75,10 @@ cfgs = {
 }
 
 
-def _vgg(arch, cfg, batch_norm, pretrained, progress, weights_path=None, **kwargs):
+def _vgg(arch, cfg, batch_norm, pretrained, progress, weights_path=None, num_classes=1000, **kwargs):
     if pretrained:
         kwargs['init_weights'] = False
-    model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), **kwargs)
+    model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), num_classes=num_classes, **kwargs)
     if pretrained:
         if weights_path:
             ckpt = torch.load(weights_path)
@@ -98,7 +98,7 @@ def _vgg(arch, cfg, batch_norm, pretrained, progress, weights_path=None, **kwarg
     return model
 
 
-def build(pretrained=False, progress=True, weights_path=None, **kwargs):
+def build(pretrained=False, progress=True, weights_path=None, num_classes=1000, **kwargs):
     r"""VGG 16-layer model (configuration "D")
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
 
@@ -106,10 +106,10 @@ def build(pretrained=False, progress=True, weights_path=None, **kwargs):
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
     """
-    return _vgg('vgg16', 'D', False, pretrained, progress, weights_path, **kwargs)
+    return _vgg('vgg16', 'D', False, pretrained, progress, weights_path, num_classes, **kwargs)
 
 
-def build_bn(pretrained=False, progress=True, weights_path=None, **kwargs):
+def build_bn(pretrained=False, progress=True, weights_path=None, num_classes=1000, **kwargs):
     r"""VGG 16-layer model (configuration "D") with batch normalization
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
 
@@ -117,7 +117,7 @@ def build_bn(pretrained=False, progress=True, weights_path=None, **kwargs):
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
     """
-    return _vgg('vgg16_bn', 'D', True, pretrained, progress, weights_path, **kwargs)
+    return _vgg('vgg16_bn', 'D', True, pretrained, progress, weights_path, num_classes, **kwargs)
 
 
 def reinit(model, init_layers, num_classes=2):

--- a/src/searchnets/train.py
+++ b/src/searchnets/train.py
@@ -23,6 +23,7 @@ def train(csv_file,
           method='transfer',
           pretrained=True,
           weights_path=None,
+          num_source_classes=1000,
           mode='classify',
           num_classes=2,
           learning_rate=None,
@@ -84,6 +85,10 @@ def train(csv_file,
         If ``pretrained`` is ``True`` and ``weights_path`` is ``None``,
         then the pre-trained weights will be loaded from the urls
         associated with the models.
+    num_source_classes : int
+        number of classes in source dataset that model was trained on.
+        Used when loading weights from ``weights_path``.
+        Default is 1000 (number of classes in ImageNet).
     mode : str
         training mode. One of {'classify', 'detect'}.
         'classify' is standard image classification.
@@ -250,6 +255,7 @@ def train(csv_file,
                                                       trainset=trainset,
                                                       pretrained=pretrained,
                                                       weights_path=weights_path,
+                                                      num_source_classes=num_source_classes,
                                                       new_learn_rate_layers=new_learn_rate_layers,
                                                       freeze_trained_weights=freeze_trained_weights,
                                                       base_learning_rate=base_learning_rate,


### PR DESCRIPTION
adds ability to specify number of classes in
source dataset when running TransferTrainer.

Makes it possible to work with models *not* trained
with default=1000 classes.
Need to have this flexbility,
to rule out that the size of the final linear layer
does not contribute to any effect of transfer.

- add 'num_source_classes' attribute to Train config class
- unpack NUM_SOURCE_CLASSES from config and
  pass into TrainConfig on init, in config/parse.py
- add 'num_classes' argument to alexnet.build
- add 'num_classes' argument to VGG16 build functions
- add 'num_classes' argument to cornet.build function
- fix transfer_trainer to use num_source_classes
- add 'num_source_classes' argument to searchnets.train and
  have searchnets.train pass 'num_source_classes' into TransferTrainer
- have main pass 'num_source_classes' into searchnets.train