### PR TITLE
ENH: make 'searchstims' train/test work for VSD/VOC dataset

### DIFF
--- a/src/searchnets/config/train.py
+++ b/src/searchnets/config/train.py
@@ -34,7 +34,8 @@ VALID_LOSS_FUNCTIONS = {
     'BCE',
     'CE',
     'CE-largest',
-    'CE-random'
+    'CE-random',
+    'CE-VSD'
 }
 
 
@@ -109,8 +110,9 @@ class TrainConfig:
         one hot vector querying whether a specific class is present as input.
         Default is 512.
     loss_func : str
-        type of loss function to use. One of {'CE', 'invDPrime'}. Default is 'CE',
-        the standard cross-entropy loss. 'invDprime' is inverse D prime.
+        type of loss function to use.
+        Valid loss functions listed in ``searchnets.config.train.VALID_LOSS_FUNCTIONS``.
+        Default is 'CE', the standard cross-entropy loss.
     optimizer : str
         optimizer to use. One of {'SGD', 'Adam', 'AdamW'}.
     save_acc_by_set_size_by_epoch : bool

--- a/src/searchnets/engine/abstract_trainer.py
+++ b/src/searchnets/engine/abstract_trainer.py
@@ -206,7 +206,7 @@ class AbstractTrainer:
 
             if self.mode == 'classify':
                 batch_x = batch['img'].to(self.device)
-                if self.loss_func == 'BCE' or self.loss_func == 'CE':
+                if self.loss_func in {'BCE', 'CE', 'CE-VSD'}:
                     batch_y = batch['target'].to(self.device)
                 elif self.loss_func == 'CE-largest':
                     batch_y = batch['largest'].to(self.device)
@@ -265,7 +265,7 @@ class AbstractTrainer:
                     val_metrics = self.validate()
                     self.model.train()  # switch back to train after validate calls eval
                     if self.mode == 'classify':
-                        if self.loss_func == 'CE':
+                        if self.loss_func == 'CE' or self.loss_func == 'CE-VSD':
                             val_acc_this_epoch = val_metrics['acc']
                         elif self.loss_func == 'BCE':
                             val_acc_this_epoch = val_metrics['f1']
@@ -330,7 +330,7 @@ class AbstractTrainer:
                 # ---- get output, compute loss ----
                 if self.mode == 'classify':
                     batch_x = batch['img'].to(self.device)
-                    if self.loss_func == 'BCE' or self.loss_func == 'CE':
+                    if self.loss_func in {'BCE', 'CE', 'CE-VSD'}:
                         batch_y = batch['target'].to(self.device)
                     elif self.loss_func == 'CE-largest':
                         batch_y = batch['largest'].to(self.device)

--- a/src/searchnets/engine/tester.py
+++ b/src/searchnets/engine/tester.py
@@ -179,7 +179,7 @@ class Tester:
                                              vis_sys_n_out=vis_sys_n_features_out,
                                              embedding_n_out=embedding_n_out)
 
-        if loss_func in {'CE', 'CE-largest', 'CE-random'}:
+        if loss_func in {'CE', 'CE-largest', 'CE-random', 'CE-VSD'}:
             criterion = nn.CrossEntropyLoss()
         elif loss_func == 'BCE':
             criterion = nn.BCEWithLogitsLoss()
@@ -233,7 +233,7 @@ class Tester:
 
                 if self.mode == 'classify':
                     batch_x = batch['img'].to(self.device)
-                    if self.loss_func == 'BCE' or self.loss_func == 'CE':
+                    if self.loss_func in {'BCE', 'CE', 'CE-VSD'}:
                         batch_y = batch['target'].to(self.device)
                     elif self.loss_func == 'CE-largest':
                         batch_y = batch['largest'].to(self.device)

--- a/src/searchnets/train.py
+++ b/src/searchnets/train.py
@@ -237,7 +237,7 @@ def train(csv_file,
                 'can only measure accuracy by set size with searchstims stimuli, not VSD dataset'
             )
 
-    if loss_func in {'CE', 'CE-largest', 'CE-random'}:
+    if loss_func in {'CE', 'CE-largest', 'CE-random', 'CE-VSD'}:
         criterion = nn.CrossEntropyLoss()
     elif loss_func == 'BCE':
         criterion = nn.BCEWithLogitsLoss()

--- a/src/searchnets/transforms/util.py
+++ b/src/searchnets/transforms/util.py
@@ -39,11 +39,23 @@ def get_transforms(dataset_type,
     transform, target_transform
     """
     if dataset_type == 'searchstims':
-        transform = vis_transforms.Compose(
-            [vis_transforms.ToTensor(),
-             vis_transforms.Normalize(mean=MEAN, std=STD)]
-        )
-        if loss_func == 'CE':
+        if loss_func == 'CE' or loss_func == 'BCE':
+            transform = vis_transforms.Compose(
+                [vis_transforms.ToTensor(),
+                 vis_transforms.Normalize(mean=MEAN, std=STD)]
+            )
+        elif loss_func == 'CE-VSD':
+            # added just to deal with the case where we train on VSD as if it were searchstims,
+            # i.e. binary classification of target present / absent, with output of size 2 + cross-entropy loss
+            # img transform is the same regardless of the loss
+            transform = vis_transforms.Compose(
+                [vis_transforms.ToTensor(),
+                 vis_transforms.Normalize(mean=MEAN, std=STD),  # note didn't normalize for VSD training below
+                 transforms.RandomPad(pad_size=pad_size),
+                 ]
+            )
+
+        if loss_func == 'CE' or loss_func == 'CE-VSD':
             target_transform = transforms.TensorFromNumpyScalar()
         elif loss_func == 'BCE':
             dim_adder = functools.partial(torch.unsqueeze, dim=0)


### PR DESCRIPTION
make it possible to train with Pascal VOC dataset images,
using the .csv representing the
Visual Search Difficulty dataset,
by converting that .csv to the same format used by
'searchstims'.
(See paper repo for script that does this.)

Key change is to add 'CE-VSD' loss,
that causes training with 'searchstims'
to use a different set of transforms

- add 'CE-VSD' loss to transforms.get_transforms
  + this returns the padding transform for the image,
    plus ImageNet normalization,
    instead of the searchstims image transform.

- then add 'CE-VSD' loss everywhere else to avoid crashes.
  + probably a more elegant / general way to handle this,
    but just doing this for now

  + add 'CE-VSD' to VALID_LOSS_FUNCTIONS in searchnets/config/train.py
  + add 'CE-VSD' to losses in searchnets/train.py
  + add 'CE-VSD' in several places in AbstractTrainer
  + add 'CE-VSD' loss in engine/tester.py